### PR TITLE
docs: Mention the AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ git clone git@github.com:ztroop/dead-ringer.git && cd ./dead-ringer
 cargo install --path .
 ```
 
+### From the AUR
+
+```sh
+paru -S dead-ringer
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
I created an AUR package: <https://aur.archlinux.org/packages/dead-ringer>

This PR simply adds instructions to README.md :bear:
